### PR TITLE
Modified Alert styles to match the current UX specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
+## <next>
+* Modified styles to match the current UX specifications
+
 ## 2.0.3
 * Update react and react-dom packages
 

--- a/examples/components/alerts-view/alerts-view.component.jsx
+++ b/examples/components/alerts-view/alerts-view.component.jsx
@@ -3,6 +3,12 @@ import { Button, ButtonToolbar } from 'react-bootstrap';
 import { OCAlertsProvider, OCAlert } from '../../../src/index';
 
 function AlertsView() {
+  const msgs = {
+    info: 'Alert info!',
+    success: 'Alert success! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel posuere sapien.',
+    warning: 'Alert warning! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel posuere sapien. Sed quis sagittis lorem. Proin eget ultrices orci. Quisque tincidunt mattis magna, vel vehicula elit congue sed.',
+    error: 'Alert error! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel posuere sapien. Sed quis sagittis lorem. Proin eget ultrices orci. Quisque tincidunt mattis magna, vel vehicula elit congue sed. Aenean interdum, quam vel molestie tempor, purus erat porttitor nulla, eget accumsan risus lectus sit amet tortor.'
+  };
   return (
     <div className="oc-content">
       <h1>Alerts</h1>
@@ -13,23 +19,27 @@ function AlertsView() {
       </p>
       <ButtonToolbar>
         <Button
-          bsStyle="info" onClick={() => {
-            OCAlert.alertInfo('alert info!');
+          bsStyle="info"
+          onClick={() => {
+            OCAlert.alertInfo(msgs.info);
           }}
         >Info</Button>
         <Button
-          bsStyle="success" onClick={() => {
-            OCAlert.alertSuccess('alert success!');
+          bsStyle="success"
+          onClick={() => {
+            OCAlert.alertSuccess(msgs.success);
           }}
         >Success</Button>
         <Button
-          bsStyle="warning" onClick={() => {
-            OCAlert.alertWarning('alert warning!');
+          bsStyle="warning"
+          onClick={() => {
+            OCAlert.alertWarning(msgs.warning);
           }}
         >Warning</Button>
         <Button
-          bsStyle="danger" onClick={() => {
-            OCAlert.alertError('alert error!');
+          bsStyle="danger"
+          onClick={() => {
+            OCAlert.alertError(msgs.error);
           }}
         >Error</Button>
       </ButtonToolbar>

--- a/src/alerts/alert.component.jsx
+++ b/src/alerts/alert.component.jsx
@@ -62,14 +62,18 @@ export class OCAlert extends React.Component {
 
   handleAlertDismiss = () => {
     alertAction.closeAlert(this.props.id);
-  }
+  };
 
   render() {
     return (
       <Alert bsStyle={this.props.type} onDismiss={this.handleAlertDismiss}>
         <div className="alert-content">
-          { this.getIcon() }
-          <span>{this.getMessage()}</span>
+          <div className="alert-icon-container">
+            {this.getIcon()}
+          </div>
+          <div className="alert-message">
+            <span>{this.getMessage()}</span>
+          </div>
         </div>
       </Alert>);
   }

--- a/src/alerts/alerts.actions.js
+++ b/src/alerts/alerts.actions.js
@@ -18,13 +18,15 @@ class OCAlertComponent {
     this.store = store;
   }
 
-  alertSuccess(message, translate = false, values = null) {
+  alertSuccess(message, translate = false, values = null, timeout = 2000) {
     const id = this.getId();
     this.store.dispatch(this.showAlert(
       id, 'success', message, translate, values));
-    setTimeout(() => {
-      this.store.dispatch(this.dismissAlert(id));
-    }, 1500);
+    if (timeout) {
+      setTimeout(() => {
+        this.store.dispatch(this.dismissAlert(id));
+      }, timeout);
+    }
     return id;
   }
 
@@ -63,7 +65,7 @@ class OCAlertComponent {
   }
 
   showAlert(id, type, message, translate,
-    values = null) {
+            values = null) {
     return {
       id,
       type: TYPES.PLATFORM_ALERTS_SHOW,

--- a/src/alerts/alerts.scss
+++ b/src/alerts/alerts.scss
@@ -1,78 +1,86 @@
 @import 'colors';
 
-
 #global-notification {
-    position:absolute;
-    z-index: 10000;
-    bottom: 15%;
+  position: absolute;
+  z-index: 10000;
+  bottom: 15%;
+  width: 100%;
+  left: 50%;
+  transform: translate3d(-50%, 0, 0);
+  max-width: 650px;
+
+  .cover {
+    border: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
     width: 100%;
-    left:50%;
-    transform: translate3d(-50%,0,0);
-    max-width: 650px;
+    z-index: -1;
+  }
 
-    .cover {
-        border: none;
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        z-index: -1;
+  img {
+    height: 38px;
+    width: 38px;
+  }
+
+  .alert {
+    $bottom-border-width: 6px;
+
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+    margin: 20px auto 15px;
+    border: none;
+    border-bottom: $bottom-border-width solid;
+    font-size: 110%;
+    background: $oc-color-toast-background;
+    overflow: hidden;
+    color: $oc-color-black;
+    display: flex;
+    flex-direction: row-reverse;
+
+    &.alert-success {
+      border-color: $oc-color-success;
     }
 
-    img {
-        height: 38px;
-        width: 38px;
+    &.alert-info {
+      border-color: $oc-color-info;
     }
 
-    .alert {
-        line-height: 1.846;
-        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-                    0 3px 1px -2px rgba(0, 0, 0, 0.2),
-                    0 1px 5px 0 rgba(0, 0, 0, 0.12);
-        margin: 20px auto 0;
-        border-style: solid;
-        border-width: 0px 0px 6px 0px;
-        font-size: 110%;
-        background: $oc-color-toast-background;
-        position: relative;
-        overflow: hidden;
-        margin-bottom: 15px;
-        color: $oc-color-black;
+    &.alert-warning {
+      border-color: $oc-color-warning;
+    }
 
-        &.alert-success {
-            border-color: $oc-color-success;
-        }
+    &.alert-danger {
+      border-color: $oc-color-error;
+    }
 
-        &.alert-info {
-            border-color: $oc-color-info;
-        }
-
-        &.alert-warning {
-            border-color: $oc-color-warning;
-        }
-
-        &.alert-danger {
-            border-color: $oc-color-error;
-        }
-
-        .close {
-            font-size: 34px;
-            font-weight: 300;
-            line-height: 24px;
-            opacity: 0.6;
-            text-shadow:none;
-            &:hover {
-                opacity: 1;
-            }
-        }
-
+    .close {
+      font-size: 34px;
+      font-weight: 300;
+      line-height: 24px;
+      opacity: 0.6;
+      text-shadow: none;
+      align-self: flex-start;
+      &:hover {
+        opacity: 1;
+      }
     }
 
     .alert-content {
       display: flex;
       flex-direction: row;
       align-items: center;
+      width: 100%;
     }
 
+    .alert-icon-container {
+      min-width: 38px;
+      margin-right: 15px;
+      svg {
+        margin-top: $bottom-border-width;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Taken from the specs:

There are 4 types of notifications: Warning, Info, Success, and Error.

1. Big icon surrounded the same marginal in every side. (Icon must be same size in every notification)
2. Text can go to 1 or many lines, but is must not affect the icon size. 
3. Notification may/or may not be dismissed with time out, which is 2 seconds (or 1,5, lets try and agree then) (By default, success notification has the time out)
4. If notification is not closed with time out, it has a close-icon (x) in the top right corner. (By default all three (warning, info, error) has this close icon. (But maybe this could be variable that could be set visible also in some cases when there is the timeout also)